### PR TITLE
feat: setup improvements

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -1,12 +1,12 @@
 {
   "command": {
     "generate_store": {
-      "description": "Generates a Spree starter with integration and backend modules.",
+      "description": "Generates a Spree starter with storefront and backend modules.",
       "input": {
         "project_name": "What's your project name?",
-        "integration": "Choose an integration template:",
-        "spree": "Choose a spree template:",
-        "custom_integration_repository": "What's the URL of the custom integration's git repository?",
+        "integration": "Choose a storefront:",
+        "spree": "Choose a Spree setup:",
+        "custom_integration_repository": "What's the URL of the custom frontend git repository?",
         "overwrite": "\"./{{ dir }}\" already exists. Overwrite?"
       },
       "message": {
@@ -24,19 +24,6 @@
         "dependency_not_found": "Could not find \"{{ name }}\" on your machine. Please install it before running Spree CLI",
         "dependency_version_mismatch": "The configuration you chose requires \"{{ name }}\" \"{{ expectedVersion }}\", while version \"{{ currentVersion }}\" is currently installed. Please install the correct version before running Spree CLI",
         "error": "ERROR"
-      }
-    },
-    "generate_template": {
-      "description": "Generates a template of your integration's for VSF",
-      "flag": {
-        "output": "A path where the template will be generated"
-      },
-      "input": {
-        "project_name": "How would you like to name the output folder?",
-        "integration_path": "What's the path to the integration theme?"
-      },
-      "message": {
-        "success": "Sucessfully created your template at \"./{{ projectName }}\"!"
       }
     }
   },

--- a/src/commands/generate/store.ts
+++ b/src/commands/generate/store.ts
@@ -58,11 +58,11 @@ export default class GenerateStore extends Command {
       }
     ].map((m) => ({ ...m, absolutePath: `${projectDir}/${m.path}` }));
 
-    const mountGitRepository = async (dir: string, gitRepositoryURL: string) => {
+    const mountGitRepository = async (dir: string, gitRepositoryURL: string, gitRef: string) => {
       if (await existsDirectory(dir)) {
         await removeFileOrDirectory(dir);
       }
-      await cloneGitRepository({ dir, gitRepositoryURL });
+      await cloneGitRepository({ dir, gitRepositoryURL, gitRef });
       await terminateGitRepository(projectDir);
     };
 
@@ -70,10 +70,11 @@ export default class GenerateStore extends Command {
 
     await this._validateDependencies(modules);
 
-    for (const { absolutePath, template: { gitRepositoryURL, name }} of modules) {
+    for (const { absolutePath, template: { gitRepositoryURL, name, gitRef }} of modules) {
       if (!gitRepositoryURL) continue;
+      const gitRefWithDefault = gitRef || 'main';
       const shouldCreateDirectory = await createDirectory(absolutePath);
-      const fn = shouldCreateDirectory ? (async () => await mountGitRepository(absolutePath, gitRepositoryURL)) : undefined;
+      const fn = shouldCreateDirectory ? (async () => await mountGitRepository(absolutePath, gitRepositoryURL, gitRefWithDefault)) : undefined;
       repositoriesToMount.push({ name, fn });
     }
 
@@ -118,7 +119,7 @@ export default class GenerateStore extends Command {
       if (buildScript) {
         spawn(buildScript, buildOptions);
       } else {
-        this.log(t('command.generate_store.message.build_scripts_skipping', { name }));
+        this.debug(t('command.generate_store.message.build_scripts_skipping', { name }));
       }
     };
 

--- a/src/domains/git-repository/cloneGitRepository.ts
+++ b/src/domains/git-repository/cloneGitRepository.ts
@@ -6,11 +6,12 @@ import http from 'isomorphic-git/http/node';
 type Options = {
   dir: string;
   gitRepositoryURL: string;
+  gitRef: string;
 };
 
 /** Clones git repository to the project directory displaying a progress bar. */
 const cloneGitRepository = async (options: Options): Promise<void> => {
-  const { dir, gitRepositoryURL } = options;
+  const { dir, gitRepositoryURL, gitRef } = options;
 
   const bar = CliUx.ux.progress({
     fps: 64,
@@ -26,6 +27,8 @@ const cloneGitRepository = async (options: Options): Promise<void> => {
     http,
     dir,
     url: gitRepositoryURL,
+    ref: gitRef,
+    singleBranch: true,
     onProgress(progress) {
       bar.update(progress.loaded);
 

--- a/src/domains/integration/getIntegration.ts
+++ b/src/domains/integration/getIntegration.ts
@@ -30,19 +30,25 @@ const getIntegration = async (options: Options): Promise<Integration> => {
 
   const customIntegrations: CustomIntegration[] = [
     {
-      name: 'Custom integration',
+      name: 'Rails storefront',
+      buildIntegration: async ({ name }) => ({
+        name,
+        preSpreeBuildScript: 'echo "gem \'spree_frontend\'" >> $SPREE_CLI_PROJECT_NAME/$SPREE_CLI_PATH_BACKEND/Gemfile\n'
+      } as Integration)
+    },
+    {
+      name: 'No storefront (Spree Headless)',
+      buildIntegration: async () => ({
+        name: 'headless'
+      })
+    },
+    {
+      name: 'Custom storefront',
       buildIntegration: async (customIntegration) => ({
         ...customIntegration,
         gitRepositoryURL: await getGitRepositoryURL(customIntegrationRepositoryMessage)
       })
     },
-    {
-      name: 'Legacy integration',
-      buildIntegration: async ({ name }) => ({
-        name,
-        preSpreeBuildScript: 'echo "gem \'spree_frontend\'" >> $SPREE_CLI_PROJECT_NAME/$SPREE_CLI_PATH_BACKEND/Gemfile\n'
-      } as Integration)
-    }
   ];
 
   const choices = [...integrations, ...customIntegrations].map((integration) => ({

--- a/src/domains/module/Template.ts
+++ b/src/domains/module/Template.ts
@@ -1,6 +1,7 @@
 export interface Template {
   name: string;
   gitRepositoryURL?: string;
+  gitRef?: string
   documentationURL?: string;
   buildScriptURL?: string;
   dependencies?: Record<string, string>;


### PR DESCRIPTION
This PR contains a few improvements that came up during my tests:
1. Improve wording in the CLI (integration -> storefront)
2. Add "headless" setup, where there is no storefront generated by the CLI
3. Change order of storefront options
4. Add ability to create a setup that clones non-main branch (e.g. for development purposes)