### PR TITLE
Update naming of tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ It provides an interactive process for configuring Spree backend (running in Doc
 To get started, simply run the following command in your terminal:
 
 ```bash
-npx @spree/cli generate store
+npx @spree/cli generate new
 ```
 
-This will launch the interactive process that will guide you through the process of setting up a new Spree-based store. Happy hacking!
+This will launch the interactive process that will guide you through the process of setting up a new Spree-based application. Happy hacking!
 
 Note: Node 14+ is required to run the CLI. Depending on your configuration, the CLI will also prompt you to install additional dependencies required by your desired setup.
 
@@ -32,7 +32,7 @@ If you have encountered any other problem with NextJS you can also refer to Next
 
 ## Overview
 
-This repository contains CLI to integrate spree and storefront of your choice
+This repository contains CLI to integrate Spree and storefront of your choice
 
 This repository is being developed and maintained by [Upside](https://upsidelab.io)
 

--- a/__tests__/infrastructures/i18next.spec.ts
+++ b/__tests__/infrastructures/i18next.spec.ts
@@ -36,7 +36,7 @@ describe('infrastructures/i18next | integration tests', () => {
 
     await setupI18Next();
 
-    const text = t('command.generate_store.description');
+    const text = t('command.generate_new.description');
 
     expect(text).toBe('Generates a Spree starter with integration and backend modules.');
   });

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -1,7 +1,7 @@
 {
   "command": {
-    "generate_store": {
-      "description": "Generates a Spree starter with storefront and backend modules.",
+    "generate_new": {
+      "description": "Generates a Spree project with storefront and backend modules.",
       "input": {
         "project_name": "What's your project name?",
         "integration": "Choose a storefront:",

--- a/src/commands/generate/new.ts
+++ b/src/commands/generate/new.ts
@@ -21,8 +21,8 @@ import existsDirectory from '../../domains/directory/existsDirectory';
 import { removeFileOrDirectory } from '../../domains/directory';
 import checkDependency from '../../domains/dependencies/checkDependencies';
 
-export default class GenerateStore extends Command {
-  static override description = t('command.generate_store.description');
+export default class GenerateNew extends Command {
+  static override description = t('command.generate_new.description');
 
   static override examples = ['<%= config.bin %> <%= command.id %>'];
 
@@ -32,17 +32,17 @@ export default class GenerateStore extends Command {
 
   async run(): Promise<void> {
     const variables = await (async () => {
-      const projectName = await getProjectName(t('command.generate_store.input.project_name'));
+      const projectName = await getProjectName(t('command.generate_new.input.project_name'));
       return useVariables({ projectName });
     })();
 
     const projectDir = path.resolve(variables.projectName);
 
-    const spree = await getSpree({ message: t('command.generate_store.input.spree') });
+    const spree = await getSpree({ message: t('command.generate_new.input.spree') });
 
     const integration = await getIntegration({
-      message: t('command.generate_store.input.integration'),
-      customIntegrationRepositoryMessage: t('command.generate_store.input.custom_integration_repository')
+      message: t('command.generate_new.input.integration'),
+      customIntegrationRepositoryMessage: t('command.generate_new.input.custom_integration_repository')
     });
 
     const modules: Module[] = [
@@ -82,17 +82,17 @@ export default class GenerateStore extends Command {
       if (fn) {
         await fn();
       } else {
-        this.log(t('command.generate_store.message.skipping', { name }));
+        this.log(t('command.generate_new.message.skipping', { name }));
       }
     }
 
     this.log('');
-    this.log(t('command.generate_store.message.success', { projectName: variables.projectName }));
+    this.log(t('command.generate_new.message.success', { projectName: variables.projectName }));
     this.log('');
 
     const logModuleDocumentation = ({ template: { documentationURL, name }}: Module) => {
       if (!documentationURL) return;
-      this.log(t('command.generate_store.message.configure', { documentationURL, name }));
+      this.log(t('command.generate_new.message.configure', { documentationURL, name }));
       this.log('');
     };
     modules.forEach(logModuleDocumentation);
@@ -103,9 +103,9 @@ export default class GenerateStore extends Command {
       const buildScript = await getBuildScript(url);
       return preBuildScript.concat(buildScript);
     };
-    CliUx.ux.action.start(t('command.generate_store.message.build_scripts'));
+    CliUx.ux.action.start(t('command.generate_new.message.build_scripts'));
     const buildScripts = await Promise.all(modules.map(fetchBuildScript));
-    CliUx.ux.action.stop(color.green(t('command.generate_store.message.done')));
+    CliUx.ux.action.stop(color.green(t('command.generate_new.message.done')));
 
     const runnersMap = modules.reduce(
       (res, { path, buildOptions, template: { name }}, i) => ({
@@ -119,7 +119,7 @@ export default class GenerateStore extends Command {
       if (buildScript) {
         spawn(buildScript, buildOptions);
       } else {
-        this.debug(t('command.generate_store.message.build_scripts_skipping', { name }));
+        this.debug(t('command.generate_new.message.build_scripts_skipping', { name }));
       }
     };
 
@@ -142,17 +142,17 @@ export default class GenerateStore extends Command {
     }
 
     for (const [name, versionString] of Object.entries(dependencies)) {
-      CliUx.ux.action.start(t('command.generate_store.message.dependency_checking', { name, expectedVersion: versionString}));
+      CliUx.ux.action.start(t('command.generate_new.message.dependency_checking', { name, expectedVersion: versionString}));
       const result = await checkDependency(name, versionString);
 
       if (result.status === 'OK') {
-        CliUx.ux.action.stop(color.green(t('command.generate_store.message.done')));
+        CliUx.ux.action.stop(color.green(t('command.generate_new.message.done')));
       } else if (result.status === 'NOT_FOUND') {
-        CliUx.ux.action.stop(color.red(t('command.generate_store.message.error')));
-        this.error(t('command.generate_store.message.dependency_not_found', { name }));
+        CliUx.ux.action.stop(color.red(t('command.generate_new.message.error')));
+        this.error(t('command.generate_new.message.dependency_not_found', { name }));
       } else if (result.status === 'VERSION_MISMATCH') {
-        CliUx.ux.action.stop(color.red(t('command.generate_store.message.error')));
-        this.error(t('command.generate_store.message.dependency_version_mismatch', { name, expectedVersion: versionString, currentVersion: result.versionFound}));
+        CliUx.ux.action.stop(color.red(t('command.generate_new.message.error')));
+        this.error(t('command.generate_new.message.dependency_version_mismatch', { name, expectedVersion: versionString, currentVersion: result.versionFound}));
       }
     }
   }

--- a/src/domains/directory/createDirectory.ts
+++ b/src/domains/directory/createDirectory.ts
@@ -7,7 +7,7 @@ const createDirectory = async (dir: string): Promise<boolean> => {
     const { overwrite } = await inquirer.prompt<{ overwrite: boolean }>({
       type: 'confirm',
       name: 'overwrite',
-      message: () => t('command.generate_store.input.overwrite', { dir })
+      message: () => t('command.generate_new.input.overwrite', { dir })
     });
     return overwrite;
   }


### PR DESCRIPTION
Technically Spree can support multiple stores, so `generate store` can be a bit misleading in that context. In fact we're generating a new project or a new app. I changed the naming to `generate new` - let me know if that makes sense to you.