### PR TITLE
feat: add new dependency checks

### DIFF
--- a/src/domains/dependencies/checkDependencies.ts
+++ b/src/domains/dependencies/checkDependencies.ts
@@ -1,15 +1,27 @@
 import type CheckDependency from './CheckDependency';
-import checkDockerVersion from './checkDockerVersion';
-import checkRubyVersion from './checkRubyVersion';
-import checkNodeVersion from './checkNodeVersion';
+import checkDockerVersion from './checkers/checkDockerVersion';
+import checkDockerComposeVersion from './checkers/checkDockerComposeVersion';
+import checkRubyVersion from './checkers/checkRubyVersion';
+import checkVipsVersion from './checkers/checkVipsVersion';
+import checkGpgVersion from './checkers/checkGpgVersion';
+import checkPostgresVersion from './checkers/checkPostgresVersion';
+import checkRedisVersion from './checkers/checkRedisVersion';
+import checkNodeVersion from './checkers/checkNodeVersion';
+import checkYarnVersion from './checkers/checkYarnVersion';
 import type DependencyCheckResult from './VersionCheckResult';
 
-type SupportedDependency = 'ruby' | 'docker' | 'node';
+type SupportedDependency = 'ruby' | 'docker' | 'vips' | 'gpg' | 'psql' | 'redis' | 'docker-compose' | 'node' | 'yarn';
 
 const dependencyMapping: Record<SupportedDependency, CheckDependency> = {
   ruby: checkRubyVersion,
   docker: checkDockerVersion,
-  node: checkNodeVersion
+  'docker-compose': checkDockerComposeVersion,
+  vips: checkVipsVersion,
+  gpg: checkGpgVersion,
+  psql: checkPostgresVersion,
+  redis: checkRedisVersion,
+  node: checkNodeVersion,
+  yarn: checkYarnVersion,
 };
 
 const checkDependency = async (dependencyName: string, versionString: string): Promise<DependencyCheckResult> => {

--- a/src/domains/dependencies/checkNodeVersion.ts
+++ b/src/domains/dependencies/checkNodeVersion.ts
@@ -1,9 +1,0 @@
-import type CheckDependency from './CheckDependency';
-import extractNodeVersion from './extractNodeVersion';
-import checkVersionByShellCommand from './checkVersionByShellCommand';
-
-const checkNodeVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('node -v', versionString, extractNodeVersion);
-};
-
-export default checkNodeVersion;

--- a/src/domains/dependencies/checkers/checkDockerComposeVersion.ts
+++ b/src/domains/dependencies/checkers/checkDockerComposeVersion.ts
@@ -1,0 +1,9 @@
+import type CheckDependency from './../CheckDependency';
+import extractDockerComposeVersion from './../versionExtractors/extractDockerComposeVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
+
+const checkDockerComposeVersion: CheckDependency = async (versionString: string) => {
+  return await checkVersionByShellCommand('docker-compose --version', versionString, extractDockerComposeVersion);
+};
+
+export default checkDockerComposeVersion;

--- a/src/domains/dependencies/checkers/checkDockerVersion.ts
+++ b/src/domains/dependencies/checkers/checkDockerVersion.ts
@@ -1,6 +1,6 @@
-import type CheckDependency from './CheckDependency';
-import extractDockerVersion from './extractDockerVersion';
-import checkVersionByShellCommand from './checkVersionByShellCommand';
+import type CheckDependency from './../CheckDependency';
+import extractDockerVersion from './../versionExtractors/extractDockerVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkDockerVersion: CheckDependency = async (versionString: string) => {
   return await checkVersionByShellCommand('docker --version', versionString, extractDockerVersion);

--- a/src/domains/dependencies/checkers/checkGpgVersion.ts
+++ b/src/domains/dependencies/checkers/checkGpgVersion.ts
@@ -1,0 +1,9 @@
+import type CheckDependency from './../CheckDependency';
+import extractGpgVersion from './../versionExtractors/extractGpgVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
+
+const checkGpgVersion: CheckDependency = async (versionString: string) => {
+  return await checkVersionByShellCommand('gpg --version', versionString, extractGpgVersion);
+};
+
+export default checkGpgVersion;

--- a/src/domains/dependencies/checkers/checkNodeVersion.ts
+++ b/src/domains/dependencies/checkers/checkNodeVersion.ts
@@ -1,0 +1,9 @@
+import type CheckDependency from './../CheckDependency';
+import extractNodeVersion from './../versionExtractors/extractNodeVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
+
+const checkNodeVersion: CheckDependency = async (versionString: string) => {
+  return await checkVersionByShellCommand('node -v', versionString, extractNodeVersion);
+};
+
+export default checkNodeVersion;

--- a/src/domains/dependencies/checkers/checkPostgresVersion.ts
+++ b/src/domains/dependencies/checkers/checkPostgresVersion.ts
@@ -1,0 +1,9 @@
+import type CheckDependency from './../CheckDependency';
+import extractPostgresVersion from './../versionExtractors/extractPostgresVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
+
+const checkPostgresVersion: CheckDependency = async (versionString: string) => {
+  return await checkVersionByShellCommand('psql --version', versionString, extractPostgresVersion);
+};
+
+export default checkPostgresVersion;

--- a/src/domains/dependencies/checkers/checkRedisVersion.ts
+++ b/src/domains/dependencies/checkers/checkRedisVersion.ts
@@ -1,0 +1,9 @@
+import type CheckDependency from './../CheckDependency';
+import extractRedisVersion from './../versionExtractors/extractRedisVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
+
+const checkRedisVersion: CheckDependency = async (versionString: string) => {
+  return await checkVersionByShellCommand('redis-server --version', versionString, extractRedisVersion);
+};
+
+export default checkRedisVersion;

--- a/src/domains/dependencies/checkers/checkRubyVersion.ts
+++ b/src/domains/dependencies/checkers/checkRubyVersion.ts
@@ -1,6 +1,6 @@
-import type CheckDependency from './CheckDependency';
-import extractRubyVersion from './extractRubyVersion';
-import checkVersionByShellCommand from './checkVersionByShellCommand';
+import type CheckDependency from './../CheckDependency';
+import extractRubyVersion from './../versionExtractors/extractRubyVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkRubyVersion: CheckDependency = async (versionString: string) => {
   return await checkVersionByShellCommand('ruby --version', versionString, extractRubyVersion);

--- a/src/domains/dependencies/checkers/checkVipsVersion.ts
+++ b/src/domains/dependencies/checkers/checkVipsVersion.ts
@@ -1,0 +1,9 @@
+import type CheckDependency from './../CheckDependency';
+import extractVipsVersion from './../versionExtractors/extractVipsVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
+
+const checkVipsVersion: CheckDependency = async (versionString: string) => {
+  return await checkVersionByShellCommand('vips --version', versionString, extractVipsVersion);
+};
+
+export default checkVipsVersion;

--- a/src/domains/dependencies/checkers/checkYarnVersion.ts
+++ b/src/domains/dependencies/checkers/checkYarnVersion.ts
@@ -1,0 +1,9 @@
+import type CheckDependency from './../CheckDependency';
+import extractYarnVersion from './../versionExtractors/extractYarnVersion';
+import checkVersionByShellCommand from './../checkVersionByShellCommand';
+
+const checkYarnVersion: CheckDependency = async (versionString: string) => {
+  return await checkVersionByShellCommand('yarn --version', versionString, extractYarnVersion);
+};
+
+export default checkYarnVersion;

--- a/src/domains/dependencies/index.ts
+++ b/src/domains/dependencies/index.ts
@@ -1,2 +1,2 @@
-export { default as checkRubyVersion } from './checkRubyVersion';
+export { default as checkRubyVersion } from './checkers/checkRubyVersion';
 export { default as CheckDependency } from './CheckDependency';

--- a/src/domains/dependencies/versionExtractors/extractDockerComposeVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractDockerComposeVersion.ts
@@ -1,0 +1,9 @@
+import extractVersionByRegExp from './../extractVersionByRegExp';
+
+const versionRegExp = /^Docker Compose version v(\d+\.\d+(\.\d)?).*$/;
+
+const extractDockerComposeVersion = (output: string): string => {
+  return extractVersionByRegExp(output, versionRegExp);
+};
+
+export default extractDockerComposeVersion;

--- a/src/domains/dependencies/versionExtractors/extractDockerVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractDockerVersion.ts
@@ -1,4 +1,4 @@
-import extractVersionByRegExp from './extractVersionByRegExp';
+import extractVersionByRegExp from './../extractVersionByRegExp';
 
 const versionRegExp = /^Docker version (\d+.\d+.\d+).*$/;
 

--- a/src/domains/dependencies/versionExtractors/extractGpgVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractGpgVersion.ts
@@ -1,0 +1,9 @@
+import extractVersionByRegExp from './../extractVersionByRegExp';
+
+const versionRegExp = /^gpg \(GnuPG\) (\d+\.\d+\.\d+).*$/s;
+
+const extractGpgVersion = (output: string): string => {
+  return extractVersionByRegExp(output, versionRegExp);
+};
+
+export default extractGpgVersion;

--- a/src/domains/dependencies/versionExtractors/extractNodeVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractNodeVersion.ts
@@ -1,4 +1,4 @@
-import extractVersionByRegExp from './extractVersionByRegExp';
+import extractVersionByRegExp from './../extractVersionByRegExp';
 
 const versionRegExp = /^v(\d+\.\d+\.\d+)$/;
 

--- a/src/domains/dependencies/versionExtractors/extractPostgresVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractPostgresVersion.ts
@@ -1,0 +1,9 @@
+import extractVersionByRegExp from './../extractVersionByRegExp';
+
+const versionRegExp = /^psql \(PostgreSQL\) (\d+\.\d+(\.\d)?).*$/;
+
+const extractPostgresVersion = (output: string): string => {
+  return extractVersionByRegExp(output, versionRegExp);
+};
+
+export default extractPostgresVersion;

--- a/src/domains/dependencies/versionExtractors/extractRedisVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractRedisVersion.ts
@@ -1,0 +1,9 @@
+import extractVersionByRegExp from './../extractVersionByRegExp';
+
+const versionRegExp = /^.*v=(\d+\.\d+(\.\d)?).*$/;
+
+const extractRedisVersion = (output: string): string => {
+  return extractVersionByRegExp(output, versionRegExp);
+};
+
+export default extractRedisVersion;

--- a/src/domains/dependencies/versionExtractors/extractRubyVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractRubyVersion.ts
@@ -1,4 +1,4 @@
-import extractVersionByRegExp from './extractVersionByRegExp';
+import extractVersionByRegExp from './../extractVersionByRegExp';
 
 const versionRegExp = /^ruby (\d+\.\d+\.\d+)p.*$/;
 

--- a/src/domains/dependencies/versionExtractors/extractVipsVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractVipsVersion.ts
@@ -1,0 +1,9 @@
+import extractVersionByRegExp from './../extractVersionByRegExp';
+
+const versionRegExp = /^vips-(\d+\.\d+\.\d+).*$/;
+
+const extractVipsVersion = (output: string): string => {
+  return extractVersionByRegExp(output, versionRegExp);
+};
+
+export default extractVipsVersion;

--- a/src/domains/dependencies/versionExtractors/extractYarnVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractYarnVersion.ts
@@ -1,0 +1,9 @@
+import extractVersionByRegExp from './../extractVersionByRegExp';
+
+const versionRegExp = /^.*(\d+\.\d+\.\d+).*$/;
+
+const extractYarnVersion = (output: string): string => {
+  return extractVersionByRegExp(output, versionRegExp);
+};
+
+export default extractYarnVersion;


### PR DESCRIPTION
This PR adds support for the following dependency checks:
- docker-compose
- vips
- gpg
- postgres
- redis
- yarn

From the project structure's perspective, the dependency checkers and dependency version extractors have been move to their dedicated subfolders. The reason behind it was to make the code more readable.