### PR TITLE
feat: add load samples prompt question

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -6,6 +6,7 @@
         "project_name": "What's your project name?",
         "integration": "Choose a storefront:",
         "spree": "Choose a Spree setup:",
+        "samples": "Do you want to load the samples?",
         "custom_integration_repository": "What's the URL of the custom frontend git repository?",
         "overwrite": "\"./{{ dir }}\" already exists. Overwrite?"
       },

--- a/src/commands/generate/store.ts
+++ b/src/commands/generate/store.ts
@@ -2,6 +2,7 @@ import { Command, CliUx } from '@oclif/core';
 import color from '@oclif/color';
 import { t } from 'i18next';
 import * as path from 'path';
+import inquirer from 'inquirer';
 import { spawn } from 'child_process';
 
 import { getProjectName } from '../../domains/project-name';
@@ -38,7 +39,13 @@ export default class GenerateStore extends Command {
 
     const projectDir = path.resolve(variables.projectName);
 
-    const spree = await getSpree({ message: t('command.generate_store.input.spree') });
+    const { samples, ...spree } = await getSpree({ message: t('command.generate_store.input.spree') });
+
+    const { samples: withSamples } = await inquirer.prompt({
+      message: t('command.generate_store.input.samples') as string,
+      type: 'confirm',
+      name: 'samples'
+    });
 
     const integration = await getIntegration({
       message: t('command.generate_store.input.integration'),
@@ -47,7 +54,10 @@ export default class GenerateStore extends Command {
 
     const modules: Module[] = [
       {
-        template: spree,
+        template: withSamples && samples ? {
+          ...spree,
+          ...samples
+        } : { ...spree },
         path: variables.pathBackend,
         buildOptions: { encoding: 'utf-8', stdio: 'inherit', shell: true }
       },

--- a/src/domains/module/Template.ts
+++ b/src/domains/module/Template.ts
@@ -5,6 +5,9 @@ export interface Template {
   documentationURL?: string;
   buildScriptURL?: string;
   dependencies?: Record<string, string>;
+  samples?: {
+    buildScriptURL?: string;
+  }
 }
 
 export default Template;

--- a/src/domains/spree/fetchSpreeTemplates.ts
+++ b/src/domains/spree/fetchSpreeTemplates.ts
@@ -5,14 +5,19 @@ import { API_URL } from '../constants';
 
 const URL = `${API_URL}/spree/data.json`;
 
-type SpreeResponse = Omit<Spree, 'buildScriptURL'> & { buildScriptPath: string }
+type SpreeResponse = Omit<Spree, 'buildScriptURL'>
+  & { buildScriptPath: string }
+  & { samples: { buildScriptPath: string } }
 
 const fetchSpreeTemplates = async (): Promise<Spree[]> => {
   const response = await fetch(URL);
   const data = (await response.json()) as SpreeResponse[];
-  return data.map(({buildScriptPath, ...rest}) => ({
+  return data.map(({buildScriptPath, samples, ...rest}) => ({
     ...rest,
-    buildScriptURL: API_URL.concat(buildScriptPath)
+    buildScriptURL: API_URL.concat(buildScriptPath),
+    samples: {
+      buildScriptURL: API_URL.concat(samples.buildScriptPath),
+    }
   })) as Spree[];
 };
 


### PR DESCRIPTION
This PR adds an additional step for the load samples option (#21):
<img width="304" alt="Screenshot 2022-11-15 at 15 03 21" src="https://user-images.githubusercontent.com/35876422/201938936-a8135a5c-a95c-4622-830f-de9b256885f6.png">
Previously the setups with samples were defined as a copy of the original sample with the script path changed (which is redundant and verbose). The new templates schema proposition looks like this:
```json
[
  {
    "id": "c56e18ec-e14d-4fd9-a9a2-fb1dc4f436e5",
    "name": "Spree (dockerized)",
    "version": "docker",
    "gitRepositoryURL": "https://github.com/spree/spree_starter",
    "documentationURL": "https://dev-docs.spreecommerce.org/",
    "buildScriptPath": "/build-scripts/c56e18ec-e14d-4fd9-a9a2-fb1dc4f436e5",
    "runScriptPath": "/run-scripts/c56e18ec-e14d-4fd9-a9a2-fb1dc4f436e5",
    "dependencies": {
      "docker": ">= 20.0"
    },
    "samples": {
      "buildScriptPath": "/build-scripts/2c0877c2-5656-4310-9eac-baf3a78c38b8"
    }
  },
  {
    "id": "c56e18ec-e14d-4fd9-a9a2-fb1dc4f436e5",
    "name": "Spree 4.5.beta (dockerized)",
    "version": "docker",
    "gitRef": "spree-4-5-development",
    "gitRepositoryURL": "https://github.com/spree/spree_starter",
    "documentationURL": "https://dev-docs.spreecommerce.org/",
    "buildScriptPath": "/build-scripts/c56e18ec-e14d-4fd9-a9a2-fb1dc4f436e5",
    "runScriptPath": "/run-scripts/c56e18ec-e14d-4fd9-a9a2-fb1dc4f436e5",
    "dependencies": {
      "docker": ">= 20.0"
    },
    "samples": {
      "buildScriptPath": "/build-scripts/2c0877c2-5656-4310-9eac-baf3a78c38b8"
    }
  },
  {
    "id": "263d6436-6db5-4fab-a973-70ba7ae3c5d0",
    "name": "Spree (no docker)",
    "version": "no-docker",
    "gitRepositoryURL": "https://github.com/spree/spree_starter",
    "documentationURL": "https://dev-docs.spreecommerce.org/",
    "buildScriptPath": "/build-scripts/263d6436-6db5-4fab-a973-70ba7ae3c5d0",
    "runScriptPath": "/run-scripts/263d6436-6db5-4fab-a973-70ba7ae3c5d0",
    "dependencies": {
      "ruby": "= 3.0.3"
    },
    "samples": {
      "buildScriptPath": "/build-scripts/bfb8cc3a-b3eb-44de-b399-5adba576cd06"
    }
  },
  {
    "id": "da7cfc54-c270-46c8-96c5-c54181e0424c",
    "name": "Spree (hybrid)",
    "version": "hybrid",
    "gitRepositoryURL": "https://github.com/spree/spree_starter",
    "documentationURL": "https://dev-docs.spreecommerce.org/",
    "buildScriptPath": "/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c",
    "runScriptPath": "/run-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c",
    "dependencies": {
      "docker": ">= 20.0",
      "ruby": "= 3.0.3"
    },
    "samples": {
      "buildScriptPath": "/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef"
    }
  }
]
```