### PR TITLE
fix: add universal version extractor

### DIFF
--- a/src/domains/dependencies/checkers/checkDockerComposeVersion.ts
+++ b/src/domains/dependencies/checkers/checkDockerComposeVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractDockerComposeVersion from './../versionExtractors/extractDockerComposeVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkDockerComposeVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('docker-compose --version', versionString, extractDockerComposeVersion);
+  return await checkVersionByShellCommand('docker-compose --version', versionString, extractVersion);
 };
 
 export default checkDockerComposeVersion;

--- a/src/domains/dependencies/checkers/checkDockerVersion.ts
+++ b/src/domains/dependencies/checkers/checkDockerVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractDockerVersion from './../versionExtractors/extractDockerVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkDockerVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('docker --version', versionString, extractDockerVersion);
+  return await checkVersionByShellCommand('docker --version', versionString, extractVersion);
 };
 
 export default checkDockerVersion;

--- a/src/domains/dependencies/checkers/checkGpgVersion.ts
+++ b/src/domains/dependencies/checkers/checkGpgVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractGpgVersion from './../versionExtractors/extractGpgVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkGpgVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('gpg --version', versionString, extractGpgVersion);
+  return await checkVersionByShellCommand('gpg --version', versionString, extractVersion);
 };
 
 export default checkGpgVersion;

--- a/src/domains/dependencies/checkers/checkNodeVersion.ts
+++ b/src/domains/dependencies/checkers/checkNodeVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractNodeVersion from './../versionExtractors/extractNodeVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkNodeVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('node -v', versionString, extractNodeVersion);
+  return await checkVersionByShellCommand('node -v', versionString, extractVersion);
 };
 
 export default checkNodeVersion;

--- a/src/domains/dependencies/checkers/checkPostgresVersion.ts
+++ b/src/domains/dependencies/checkers/checkPostgresVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractPostgresVersion from './../versionExtractors/extractPostgresVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkPostgresVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('psql --version', versionString, extractPostgresVersion);
+  return await checkVersionByShellCommand('psql --version', versionString, extractVersion);
 };
 
 export default checkPostgresVersion;

--- a/src/domains/dependencies/checkers/checkRedisVersion.ts
+++ b/src/domains/dependencies/checkers/checkRedisVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractRedisVersion from './../versionExtractors/extractRedisVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkRedisVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('redis-server --version', versionString, extractRedisVersion);
+  return await checkVersionByShellCommand('redis-server --version', versionString, extractVersion);
 };
 
 export default checkRedisVersion;

--- a/src/domains/dependencies/checkers/checkRubyVersion.ts
+++ b/src/domains/dependencies/checkers/checkRubyVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractRubyVersion from './../versionExtractors/extractRubyVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkRubyVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('ruby --version', versionString, extractRubyVersion);
+  return await checkVersionByShellCommand('ruby --version', versionString, extractVersion);
 };
 
 export default checkRubyVersion;

--- a/src/domains/dependencies/checkers/checkVipsVersion.ts
+++ b/src/domains/dependencies/checkers/checkVipsVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractVipsVersion from './../versionExtractors/extractVipsVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkVipsVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('vips --version', versionString, extractVipsVersion);
+  return await checkVersionByShellCommand('vips --version', versionString, extractVersion);
 };
 
 export default checkVipsVersion;

--- a/src/domains/dependencies/checkers/checkYarnVersion.ts
+++ b/src/domains/dependencies/checkers/checkYarnVersion.ts
@@ -1,9 +1,9 @@
 import type CheckDependency from './../CheckDependency';
-import extractYarnVersion from './../versionExtractors/extractYarnVersion';
+import extractVersion from './../extractVersion';
 import checkVersionByShellCommand from './../checkVersionByShellCommand';
 
 const checkYarnVersion: CheckDependency = async (versionString: string) => {
-  return await checkVersionByShellCommand('yarn --version', versionString, extractYarnVersion);
+  return await checkVersionByShellCommand('yarn --version', versionString, extractVersion);
 };
 
 export default checkYarnVersion;

--- a/src/domains/dependencies/extractVersion.ts
+++ b/src/domains/dependencies/extractVersion.ts
@@ -1,0 +1,9 @@
+import extractVersionByRegExp from './extractVersionByRegExp';
+
+const versionRegExp = /(\d+)(\.\d+)(\.\d+)?/g;
+
+const extractVersion = (output: string): string => {
+  return extractVersionByRegExp(output, versionRegExp);
+};
+
+export default extractVersion;

--- a/src/domains/dependencies/extractVersionByRegExp.ts
+++ b/src/domains/dependencies/extractVersionByRegExp.ts
@@ -1,10 +1,10 @@
 const extractVersionByRegExp = (output: string, regExp: RegExp): string => {
   const regexResult = output.trim().match(regExp);
 
-  if (!regexResult || !regexResult[1]) {
+  if (!regexResult || !regexResult[0]) {
     throw new Error('Invalid output');
   }
-  return regexResult[1];
+  return regexResult[0];
 };
 
 export default extractVersionByRegExp;

--- a/src/domains/dependencies/versionExtractors/extractDockerComposeVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractDockerComposeVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^Docker Compose version v(\d+\.\d+(\.\d)?).*$/;
-
-const extractDockerComposeVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractDockerComposeVersion;

--- a/src/domains/dependencies/versionExtractors/extractDockerVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractDockerVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^Docker version (\d+.\d+.\d+).*$/;
-
-const extractDockerVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractDockerVersion;

--- a/src/domains/dependencies/versionExtractors/extractGpgVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractGpgVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^gpg \(GnuPG\) (\d+\.\d+\.\d+).*$/s;
-
-const extractGpgVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractGpgVersion;

--- a/src/domains/dependencies/versionExtractors/extractNodeVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractNodeVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^v(\d+\.\d+\.\d+)$/;
-
-const extractNodeVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractNodeVersion;

--- a/src/domains/dependencies/versionExtractors/extractPostgresVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractPostgresVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^psql \(PostgreSQL\) (\d+\.\d+(\.\d)?).*$/;
-
-const extractPostgresVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractPostgresVersion;

--- a/src/domains/dependencies/versionExtractors/extractRedisVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractRedisVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^.*v=(\d+\.\d+(\.\d)?).*$/;
-
-const extractRedisVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractRedisVersion;

--- a/src/domains/dependencies/versionExtractors/extractRubyVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractRubyVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^ruby (\d+\.\d+\.\d+)p.*$/;
-
-const extractRubyVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractRubyVersion;

--- a/src/domains/dependencies/versionExtractors/extractVipsVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractVipsVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^vips-(\d+\.\d+\.\d+).*$/;
-
-const extractVipsVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractVipsVersion;

--- a/src/domains/dependencies/versionExtractors/extractYarnVersion.ts
+++ b/src/domains/dependencies/versionExtractors/extractYarnVersion.ts
@@ -1,9 +1,0 @@
-import extractVersionByRegExp from './../extractVersionByRegExp';
-
-const versionRegExp = /^.*(\d+\.\d+\.\d+).*$/;
-
-const extractYarnVersion = (output: string): string => {
-  return extractVersionByRegExp(output, versionRegExp);
-};
-
-export default extractYarnVersion;


### PR DESCRIPTION
This PR adds one version extractor that works for all the possible dependencies by simply looking for a number sequence. Because of it the previously implemented per-dependency extractors were removed.

The proposed RegEx:
```
/(\d+)(\.\d+)(\.\d+)?/g
```