### PR TITLE
feat: hide beta configurations by default

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -2,6 +2,9 @@
   "command": {
     "new_app": {
       "description": "Generates a Spree project with storefront and backend modules.",
+      "flag": {
+        "beta": "Includes configurations that are currently in beta"
+      },
       "input": {
         "project_name": "What's your project name?",
         "integration": "Choose a storefront:",

--- a/src/commands/new/app.ts
+++ b/src/commands/new/app.ts
@@ -1,4 +1,4 @@
-import { Command, CliUx } from '@oclif/core';
+import { Command, CliUx, Flags } from '@oclif/core';
 import * as fs from 'fs';
 import color from '@oclif/color';
 import { t } from 'i18next';
@@ -31,11 +31,16 @@ export default class NewApp extends Command {
 
   static override examples = ['<%= config.bin %> <%= command.id %>'];
 
-  static override flags = {};
+  static override flags = {
+    beta: Flags.boolean({
+      description: t('command.new_app.flag.beta')
+    })
+  };
 
   static override args = [];
 
   async run(): Promise<void> {
+    const { flags } = await this.parse(NewApp);
     const variables = await (async () => {
       const projectName = await getProjectName(t('command.new_app.input.project_name'));
       return useVariables({ projectName });
@@ -43,7 +48,7 @@ export default class NewApp extends Command {
 
     const projectDir = path.resolve(variables.projectName);
 
-    const { samples, ...spree } = await getSpree({ message: t('command.new_app.input.spree') });
+    const { samples, ...spree } = await getSpree({ message: t('command.new_app.input.spree'), includeBeta: flags.beta });
 
     const { samples: withSamples } = await inquirer.prompt({
       message: t('command.new_app.input.samples') as string,
@@ -171,7 +176,7 @@ export default class NewApp extends Command {
         this.debug(t('command.new_app.message.build_scripts_skipping', { name }));
       }
     };
-    
+
     [variables.pathBackend, variables.pathIntegration]
       .map((path) => runnersMap[path])
       .filter(notEmpty<Runner>)

--- a/src/domains/module/Template.ts
+++ b/src/domains/module/Template.ts
@@ -8,6 +8,7 @@ export interface Template {
   runScriptURL?: string;
   runScriptLocalPath?: string;
   dependencies?: Record<string, string>;
+  beta?: boolean;
   samples?: {
     buildScriptURL?: string;
   }

--- a/src/domains/spree/getSpree.ts
+++ b/src/domains/spree/getSpree.ts
@@ -8,15 +8,18 @@ type Answers = {
 
 type Options = {
   message: string;
+  includeBeta: boolean;
 };
 
 /** Gets the integration from user's input. */
 const getSpree = async (options: Options): Promise<Spree> => {
-  const { message } = options;
+  const { message, includeBeta } = options;
 
   const spreeTemplates = await fetchSpreeTemplates();
 
-  const choices = spreeTemplates.map((spree) => ({
+  const filteredTemplates = includeBeta ? spreeTemplates : spreeTemplates.filter((e) => e.beta !== true);
+
+  const choices = filteredTemplates.map((spree) => ({
     name: spree.name,
     value: spree
   }));

--- a/src/domains/spree/getSpree.ts
+++ b/src/domains/spree/getSpree.ts
@@ -11,13 +11,19 @@ type Options = {
   includeBeta: boolean;
 };
 
+const filterTemplates = (templates: Spree[], options: Options) => {
+  if (options.includeBeta) return templates;
+
+  return templates.filter((e) => !e.beta);
+}
+
 /** Gets the integration from user's input. */
 const getSpree = async (options: Options): Promise<Spree> => {
-  const { message, includeBeta } = options;
+  const { message } = options;
 
   const spreeTemplates = await fetchSpreeTemplates();
 
-  const filteredTemplates = includeBeta ? spreeTemplates : spreeTemplates.filter((e) => e.beta !== true);
+  const filteredTemplates = filterTemplates(spreeTemplates, options);
 
   const choices = filteredTemplates.map((spree) => ({
     name: spree.name,


### PR DESCRIPTION
Currently we display Spree configurations that are not production ready. This PR introduces a `--beta` flag that can be used to enable them on demand.