### PR TITLE
feat: add recommendations depending on the platform

### DIFF
--- a/__tests__/domains/spree/buildSpreeChoices.spec.ts
+++ b/__tests__/domains/spree/buildSpreeChoices.spec.ts
@@ -1,0 +1,65 @@
+import { buildSpreeChoices } from '../../../src/domains/spree';
+import type { Spree, SpreeChoice } from '../../../src/domains/spree';
+import { setupI18Next } from '../../../src/infrastructures/i18next';
+
+describe('buildSpreeChoices | unit tests', () => {
+  const templates: Spree[] = [
+    {
+      name: 'Spree 4.5 Dockerized',
+      version: 'docker',
+      recommendedForPlatforms: ['linux', 'windows']
+    },
+    {
+      name: 'Spree 4.5 Hybrid',
+      version: 'hybrid',
+      recommendedForPlatforms: ['darwin']
+    },
+    {
+      name: 'Spree 5.0 Beta',
+      version: 'docker',
+      beta: true
+    }
+  ];
+
+  beforeAll(async () => {
+    await setupI18Next()
+  });
+
+  it('prioritizes hybrid template when platform is darwin', () => {
+    const options = {
+      includeBeta: true,
+      platform: 'darwin'
+    };
+    const result = buildSpreeChoices(templates, options);
+
+    expect(result).toHaveLength(3);
+    expect((result[0] as SpreeChoice).name).toEqual('Spree 4.5 Hybrid (Recommended)');
+    expect((result[1] as SpreeChoice).name).toEqual('Spree 4.5 Dockerized');
+    expect((result[2] as SpreeChoice).name).toEqual('Spree 5.0 Beta');
+  });
+
+  it('prioritizes docker template when platform is linux', () => {
+    const options = {
+      includeBeta: true,
+      platform: 'linux'
+    };
+    const result = buildSpreeChoices(templates, options);
+
+    expect(result).toHaveLength(3);
+    expect((result[0] as SpreeChoice).name).toEqual('Spree 4.5 Dockerized (Recommended)');
+    expect((result[1] as SpreeChoice).name).toEqual('Spree 4.5 Hybrid');
+    expect((result[2] as SpreeChoice).name).toEqual('Spree 5.0 Beta');
+  });
+
+  it('removes beta from the results when filterBeta set to false', () => {
+    const options = {
+      includeBeta: false,
+      platform: 'darwin'
+    };
+    const result = buildSpreeChoices(templates, options);
+
+    expect(result).toHaveLength(2);
+    expect((result[0] as SpreeChoice).name).toEqual('Spree 4.5 Hybrid (Recommended)');
+    expect((result[1] as SpreeChoice).name).toEqual('Spree 4.5 Dockerized');
+  })
+});

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -50,6 +50,9 @@
       "is_invalid": "Please input a valid git repository URL.",
       "was_not_found": "Couldn't locate git repository with the received URL.",
       "suggestion": "The protocol isn't supported. Use \"{{ suggestion }}\" instead?"
+    },
+    "spree": {
+      "recommended": "Recommended"
     }
   }
 }

--- a/src/commands/new/app.ts
+++ b/src/commands/new/app.ts
@@ -1,5 +1,6 @@
 import { Command, CliUx, Flags } from '@oclif/core';
 import * as fs from 'fs';
+import os from 'os';
 import color from '@oclif/color';
 import { t } from 'i18next';
 import * as path from 'path';
@@ -48,7 +49,11 @@ export default class NewApp extends Command {
 
     const projectDir = path.resolve(variables.projectName);
 
-    const { samples, ...spree } = await getSpree({ message: t('command.new_app.input.spree'), includeBeta: flags.beta });
+    const { samples, ...spree } = await getSpree({
+      message: t('command.new_app.input.spree'),
+      includeBeta: flags.beta,
+      platform: os.platform()
+    });
 
     const { samples: withSamples } = await inquirer.prompt({
       message: t('command.new_app.input.samples') as string,

--- a/src/domains/module/Template.ts
+++ b/src/domains/module/Template.ts
@@ -9,6 +9,7 @@ export interface Template {
   runScriptLocalPath?: string;
   dependencies?: Record<string, string>;
   beta?: boolean;
+  recommendedForPlatforms?: string[];
   samples?: {
     buildScriptURL?: string;
   }

--- a/src/domains/spree/Options.ts
+++ b/src/domains/spree/Options.ts
@@ -1,0 +1,7 @@
+import type { UserOptions } from '.';
+
+type Options = UserOptions & {
+  message: string;
+};
+
+export default Options;

--- a/src/domains/spree/SpreeChoice.ts
+++ b/src/domains/spree/SpreeChoice.ts
@@ -1,0 +1,8 @@
+import type { Spree } from '.';
+
+type SpreeChoice = {
+  name: string;
+  value: Spree;
+};
+
+export default SpreeChoice;

--- a/src/domains/spree/UserOptions.ts
+++ b/src/domains/spree/UserOptions.ts
@@ -1,0 +1,6 @@
+type UserOptions = {
+  platform: string;
+  includeBeta: boolean;
+};
+
+export default UserOptions;

--- a/src/domains/spree/buildSpreeChoices.ts
+++ b/src/domains/spree/buildSpreeChoices.ts
@@ -1,0 +1,31 @@
+import { t } from 'i18next';
+import type { UserOptions, Spree, SpreeChoice } from '.';
+
+
+const filterTemplates = (templates: Spree[], includeBeta: Boolean) => {
+  if (includeBeta) return templates;
+
+  return templates.filter((e) => !e.beta);
+};
+
+export const buildSpreeChoices = (templates: Spree[], options: UserOptions) => {
+  const { includeBeta, platform } = options;
+  const filteredTemplates = filterTemplates(templates, includeBeta);
+
+  const choices = filteredTemplates.map((template) => ({
+    name: template.name,
+    value: template
+  }));
+
+  const recommendedChoiceIndex = choices.findIndex((e) => e.value.recommendedForPlatforms?.includes(platform));
+  if (recommendedChoiceIndex !== -1) {
+    const recommendedChoice = choices[recommendedChoiceIndex] as SpreeChoice;
+    recommendedChoice.name += ` (${t('domain.spree.recommended')})`;
+    choices.splice(recommendedChoiceIndex, 1);
+    choices.unshift(recommendedChoice);
+  }
+
+  return choices;
+};
+
+export default buildSpreeChoices;

--- a/src/domains/spree/getSpree.ts
+++ b/src/domains/spree/getSpree.ts
@@ -1,34 +1,19 @@
 import inquirer from 'inquirer';
 import type { Spree } from '.';
-import { fetchSpreeTemplates } from '.';
+import { fetchSpreeTemplates, buildSpreeChoices } from '.';
+import type { Options } from '.';
 
 type Answers = {
   spree: Spree;
 };
 
-type Options = {
-  message: string;
-  includeBeta: boolean;
-};
-
-const filterTemplates = (templates: Spree[], options: Options) => {
-  if (options.includeBeta) return templates;
-
-  return templates.filter((e) => !e.beta);
-}
-
 /** Gets the integration from user's input. */
 const getSpree = async (options: Options): Promise<Spree> => {
   const { message } = options;
 
-  const spreeTemplates = await fetchSpreeTemplates();
+  const templates = await fetchSpreeTemplates();
 
-  const filteredTemplates = filterTemplates(spreeTemplates, options);
-
-  const choices = filteredTemplates.map((spree) => ({
-    name: spree.name,
-    value: spree
-  }));
+  const choices = buildSpreeChoices(templates, options);
 
   const answers = await inquirer.prompt<Answers>({
     choices,

--- a/src/domains/spree/index.ts
+++ b/src/domains/spree/index.ts
@@ -1,3 +1,7 @@
 export { default as fetchSpreeTemplates } from './fetchSpreeTemplates';
 export { default as getSpree } from './getSpree';
+export { default as buildSpreeChoices} from './buildSpreeChoices';
+export { default as Options } from './Options';
+export { default as UserOptions } from './UserOptions';
 export { default as Spree } from './Spree';
+export { default as SpreeChoice } from './SpreeChoice';


### PR DESCRIPTION
This PR adds a support for recommendedForPlatforms field in Spree Template.s

We've noticed that a lot of people try to use the dockerized version on Mac, which has some severe performance issues caused by the slow filesystem sync between mac and docker. For an application of this size, this causes it to work really slow.

With this PR, it's possible to tag a template as recommended for a certain platform - in such case, the CLI will prioritize it when running on given OS and will display "Recommended" next to the name of the template.